### PR TITLE
Variable substitution in include paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var async = require('async');
 var syntaxReg = /<!--#([^\r\n]+?)-->/mg;
 var includeFileReg = /<!--#\s*include\s+(file|virtual)=(['"])([^\r\n\s]+?)\2\s*(.*?)-->/;
 var setVarReg = /<!--#\s*set\s+var=(['"])([^\r\n]+?)\1\s+value=(['"])([^\r\n]*?)\3\s*-->/;
-var echoReg = /<!--#\s*echo\s+var=(['"])([^\r\n]+?)\1(\s+default=(['"])([^\r\n]+?)\4)?\s*-->/;
+var echoReg = /<!--#\s*echo\s+var=(['"])([^\r\n]+?)\1(\s+default=(['"])([^\r\n]*?)\4)?\s*-->/;
 var ifReg = /<!--#\s*if\s+expr=(['"])([^\r\n]+?)\1\s*-->/;
 var elifReg = /<!--#\s*elif\s+expr=(['"])([^\r\n]+?)\1\s*-->/;
 var elseReg = /<!--#\s*else\s*-->/;

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function resolve(tpl) {
 
     fnStr += '};\nreturn _r;';
 
-    return new Function('__data', fnStr);
+  return new Function('__data', fnStr);
 }
 
 /**
@@ -197,15 +197,22 @@ SSI.prototype = {
      * @param callback
      */
     resolveIncludes: function(content, options, callback) {
-        var matches, seg, isVirtual, basePath, tpath, subOptions, ssi = this;
+        var matches, seg, isVirtual, basePath, tpath, subOptions, target, ssi = this;
 
         async.whilst( // https://www.npmjs.org/package/async#whilst-test-fn-callback-
             function test() {return !!(matches = includeFileReg.exec(content)); },
             function insertInclude(next) {
-                seg = matches[0];
                 isVirtual = RegExp.$1 == 'virtual';
-                basePath = (isVirtual && options.dirname && RegExp.$3.charAt(0) !== '/')? options.dirname : options.baseDir;
-                tpath = path.join(basePath, RegExp.$3);
+        target = RegExp.$3.replace(
+              /\$(?:\{([^}]+)\}|(\w+))/g,
+              function( _, m1, m2 ) {
+                return options.payload[m1||m2] || ""
+              }
+             );
+
+                seg = matches[0];
+                basePath = (isVirtual && options.dirname && target.charAt(0) !== '/')? options.dirname : options.baseDir;
+                tpath = path.join(basePath, target);
                 fs.lstat(tpath,
                     function(err, stats) {
                         if (err) {


### PR DESCRIPTION
```<!--# include file="path/name$suffix.css" -->```

```<!--# include file="path/${name}suffix.css" -->```

This minimalistic patch can only substitute variables supplied via `options.payload`, not those defined via `#set` SSI directives.

Also fixes a bug in `#echo` parser that manifested on `default=""`.